### PR TITLE
Fix check for bookmarks

### DIFF
--- a/src/parse.go
+++ b/src/parse.go
@@ -211,7 +211,7 @@ func ParseHighlight(line string) (Highlight, error) {
 		return Highlight{}, nil
 	}
 
-	isBookmark := strings.Contains(sublines[1], "Your Bookmark on ")
+	isBookmark := strings.HasPrefix(sublines[1], "- Your Bookmark ")
 
 	if isBookmark {
 		return Highlight{}, nil


### PR DESCRIPTION
If a book doesn't have line numbers then the clipping reads "- Your
Bookmark at location ..." instead of "- Your Bookmark on page...".

Check for the initial string "- Your Bookmark" to match both of
these possibilities.

Closes #2